### PR TITLE
Fix #6 - handle identifiers with spaces

### DIFF
--- a/lib/sbconstants/objc_constant_writer.rb
+++ b/lib/sbconstants/objc_constant_writer.rb
@@ -19,12 +19,12 @@ module SBConstants
     end
 
     def header
-      template_with_file "\n", %Q{extern NSString * const <%= constant %>;\n}
+      template_with_file "\n", %Q{extern NSString * const <%= sanitise_key(constant) %>;\n}
     end
 
     def implementation
       head = %Q{#import "<%= File.basename(options.output_path) %>.h"\n\n}
-      body = %Q{NSString * const <%= constant %> = @"<%= constant %>";\n}
+      body = %Q{NSString * const <%= sanitise_key(constant) %> = @"<%= constant %>";\n}
       template_with_file head, body
     end
 

--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -10,7 +10,7 @@ module SBConstants
 
     def write
       head = %Q{\nimport Foundation"\n}
-      body = %Q{    case <%= constant.gsub(" ", "").gsub("-", "") %> = "<%= constant %>"\n}
+      body = %Q{    case <%= sanitise_key(constant) %> = "<%= constant %>"\n}
       @swift_out.puts template_with_file head, body
     end
 


### PR DESCRIPTION
If an identifier has a space or a hyphen we should sanitise the key by stripping these characters.
We should also ensure that this does not create any collisions with existing keys or throw an error
