### PR TITLE
Added option to remove space after '*' prior const declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage: DESTINATION_FILE [options]
     -q, --queries=<queries>          YAML file containing queries
     -d, --dry-run                    Output to STDOUT
     -v, --verbose                    Verbose output
+    -r, --remove-space               Remove space before * on const declaration "NSString const*" vs "NSString const *"
 ```
 
 ## Contributing

--- a/lib/sbconstants/objc_constant_writer.rb
+++ b/lib/sbconstants/objc_constant_writer.rb
@@ -19,12 +19,14 @@ module SBConstants
     end
 
     def header
-      template_with_file "\n", %Q{extern NSString * const <%= sanitise_key(constant) %>;\n}
+      middlespace = options.space_after_star ? " " : "" 
+      template_with_file "\n", %Q{extern NSString *#{middlespace}const <%= sanitise_key(constant) %>;\n}
     end
 
     def implementation
+      middlespace = options.space_after_star ? " " : "" 
       head = %Q{#import "<%= File.basename(options.output_path) %>.h"\n\n}
-      body = %Q{NSString * const <%= sanitise_key(constant) %> = @"<%= constant %>";\n}
+      body = %Q{NSString *#{middlespace}const <%= sanitise_key(constant) %> = @"<%= constant %>";\n}
       template_with_file head, body
     end
 

--- a/lib/sbconstants/options.rb
+++ b/lib/sbconstants/options.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module SBConstants
   class Options
-    attr_accessor :dry_run, :prefix, :destination, :query_config, :output_path, :source_dir, :verbose, :query_file, :use_swift
+    attr_accessor :dry_run, :prefix, :destination, :query_config, :output_path, :source_dir, :verbose, :query_file, :use_swift, :space_after_star
 
     def self.parse argv
       options = self.new
@@ -33,6 +33,10 @@ module SBConstants
         opts.on('-v', '--verbose', 'Verbose output') do |verbose|
           options.verbose = verbose
         end
+
+        opts.on('-r', '--remove-space', 'Remove space before * on const declaration "NSString const*" vs "NSString const *"') do |verbose|
+          options.space_after_star = false
+        end
       end.parse!(argv)
 
       if argv.first.nil?
@@ -47,6 +51,7 @@ module SBConstants
     def initialize
       self.query_file = File.expand_path('../../sbconstants/identifiers.yml', __FILE__)
       self.source_dir = Dir.pwd
+      self.space_after_star = true
     end
 
     def queries


### PR DESCRIPTION
This has been a pretty valuable tool for us; now not having to depend on manual addition of constants.
However the generated code didn't match our coding standards and with [Objective-Clean](http://objclean.com/index.php) build phase in place we had to manually fix the code after generating it.

I forked the gem and added an option that removes this space if the option is present; if not it will generate the code like you have it (keeping default behavior to avoid issues with people already using the gem).

New option is `-r` and will produce constants like this:

``` objc
extern NSString *const HSGuidedFlow; // On the .h
```

``` objc
NSString *const HSGuidedFlow = @"HSGuidedFlow"; // On the .m
```

Everything else is kept the same; the only change is now the ability to specify wether or not to have a space after the `*`.
Don't know if this is valuable for anyone else but I figure if I was going to fork and add it I might as well make it available for you to judge if its worth merging.
