### PR TITLE
Add Foundation import to ObjC headers.

### DIFF
--- a/lib/sbconstants/objc_constant_writer.rb
+++ b/lib/sbconstants/objc_constant_writer.rb
@@ -22,7 +22,7 @@ module SBConstants
     end
 
     def header
-      template_with_file "\n", File.open(template_file_path("objc_header.erb")).read
+      template_with_file "#import <Foundation/Foundation.h>\n\n", File.open(template_file_path("objc_header.erb")).read
     end
 
     def implementation


### PR DESCRIPTION
If not present, outputs breaks when not using prefix headers, which is the default for projects generated by Xcode 6.
