### PR TITLE
Fix #17 - verbose option crash

### DIFF
--- a/lib/sbconstants/templates/objc_body.erb
+++ b/lib/sbconstants/templates/objc_body.erb
@@ -6,7 +6,7 @@
 <%% present_constants(section).each do |constant_name, constant_value| %>
 <%% if options.verbose %>
 //
-<%% constants[constant].each do |location| %>
+<%% constants[constant_name].each do |location| %>
 //    info: <%%= location.debug %>
 // context: <%%= location.context %>
 //


### PR DESCRIPTION
When this code was refactored the variable name was not updated correctly