### PR TITLE
Switching from enums to structs

### DIFF
--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -10,7 +10,7 @@ module SBConstants
 
     def write
       head = %Q{\nimport Foundation"\n}
-      body = %Q{    case <%= sanitise_key(constant) %> = "<%= constant %>"\n}
+      body = %Q{    static let <%= sanitise_key(constant) %> = "<%= constant %>"\n}
       @swift_out.puts template_with_file head, body
     end
 

--- a/lib/sbconstants/templates/swift_body.erb
+++ b/lib/sbconstants/templates/swift_body.erb
@@ -1,7 +1,7 @@
 // Auto generated file from SBConstants - any changes may be lost
 <%% sections.each do |section| %>
 
-public enum <%%= section.pretty_title %> : String {
+public struct <%%= section.pretty_title %> {
 <%% section.constants.each do |constant| %>
 <%% if options.verbose %>
 //


### PR DESCRIPTION
Hi, I would like to suggest a change from enums to structs

That way the resulting .swift file will be something like this, and will allow us to use them without calling .rawValue on each of them

``` swift
public struct SegueIdentifiers {
        static let AttachmentsScreen = "AttachmentsScreenSegue"
        static let TagsScreen = "TagsScreenSegue"
        static let TeamsScreen = "TeamsScreenSegue"
}
```