### PR TITLE
use modules import style

### DIFF
--- a/lib/sbconstants/objc_constant_writer.rb
+++ b/lib/sbconstants/objc_constant_writer.rb
@@ -22,7 +22,7 @@ module SBConstants
     end
 
     def header
-      template_with_file "#import <Foundation/Foundation.h>\n\n", File.open(template_file_path("objc_header.erb")).read
+      template_with_file "@import Foundation;\n\n", File.open(template_file_path("objc_header.erb")).read
     end
 
     def implementation


### PR DESCRIPTION
The Xcode 6.3.1 Show warning when using `#Import <Foundation.h>` style 
Result file
```
// Auto generated file - any changes will be lost

@import Foundation;

#pragma mark - storyboardNames
....
```
