### PR TITLE
Identifiers to allow use on WatchKit Storyboards

### DIFF
--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -1,6 +1,8 @@
 ---
 segue: identifier
 view: restorationIdentifier
+controller: identifier
+tableRow: identifier
 ? - tableViewCell
   - collectionViewCell
 : - reuseIdentifier


### PR DESCRIPTION
Add identifiers used in WatchKit Storyboards, to help with stringly typed controllers and tableRows.