### PR TITLE
Fix capitalization on reuse and remove more problematic characters

### DIFF
--- a/lib/sbconstants/cli.rb
+++ b/lib/sbconstants/cli.rb
@@ -39,7 +39,7 @@ module SBConstants
     end
     
     def sanitise_key key
-      key.gsub(" ", "").gsub("-", "")
+      key.gsub(" ", "").gsub("-", "").gsub("@", "").gsub(":", "")
     end
 
     private

--- a/lib/sbconstants/section.rb
+++ b/lib/sbconstants/section.rb
@@ -8,6 +8,7 @@ module SBConstants
                                .gsub("identifier", "Identifier")
                                .gsub("viewcontroller", "ViewController")
                                .gsub("storyboard", "Storyboard")
+                               .gsub("reuse", "Reuse")
 
       title.slice(0,1).capitalize + title.slice(1..-1)
     end


### PR DESCRIPTION
Bugged me that reuse was not capitalized and removed more problematic characters from the keys.