### PR TITLE
Removed the right hand side of the cases in Swift

### DIFF
--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -10,7 +10,7 @@ module SBConstants
 
     def write
       head = %Q{\nimport Foundation"\n}
-      body = %Q{    case <%= sanitise_key(constant) %> = "<%= constant %>"\n}
+      body = %Q{    case <%= sanitise_key(constant) %>\n}
       @swift_out.puts template_with_file head, body
     end
 


### PR DESCRIPTION
This is not necessary anymore, anything String will default to the case name