### PR TITLE
Add  "viewControllerPlaceholder" to identifiers.yml

### DIFF
--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -9,5 +9,6 @@ view: restorationIdentifier
   - viewController
   - tableViewController
   - collectionViewController
+  - viewControllerPlaceholder
 : - storyboardIdentifier
   - restorationIdentifier


### PR DESCRIPTION
This allows to use new Xcode 7 feature of "Storyboard Placeholders" with SBConstants.