### PR TITLE
Close file is not needed if it's using dry_run

### DIFF
--- a/lib/sbconstants/cli.rb
+++ b/lib/sbconstants/cli.rb
@@ -94,7 +94,7 @@ To resolve the issue remove the ambiguity in naming - search your storyboards fo
       if options.use_swift
           swift_out = File.open("#{options.output_path}.swift", 'w') unless dry_run
           SwiftConstantWriter.new(self, swift_out, options.templates_dir).write
-          swift_out.close
+          swift_out.close unless dry_run
       else
 
         int_out = File.open("#{options.output_path}.h", 'w') unless dry_run


### PR DESCRIPTION
`close` only should be called when file was opened, and it happens only if dry_run is not set
