### PR TITLE
Allow namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For manual use (using swift):
 $ sbconstants -h
 Usage: DESTINATION_FILE [options]
     -d, --dry-run                    Output to STDOUT
+    -n, --namespace=<namespace>      Prefix each constant with <namespace>
     -p, --prefix=<prefix>            Only match identifiers with <prefix>
     -s, --source-dir=<source>        Directory containing storyboards
     -t, --templates-dir=<templates>  Directory containing the templates to use for code formatting
@@ -105,6 +106,11 @@ The constants are grouped by where they were found in the storyboard xml e.g. `s
 ##Options
 
 Options are fun and there are a few to play with - most of these options are really only any good for debugging.
+
+####`--namespace`
+    -n, --namespace=<namespace>      Prefix each constant with <namespace>
+
+If you need to add a prefix to each constant generated, you can use `namespace` option. This is useful if you have issues with XIBs file constant names and classnames (usually `Whatever.xib` is associated with `Whatever` classname, so compiler will return an error).
 
 ####`--prefix`
     -p, --prefix=<prefix>            Only match identifiers with <prefix>

--- a/lib/sbconstants.rb
+++ b/lib/sbconstants.rb
@@ -2,6 +2,7 @@ module SBConstants
 end
 
 require 'sbconstants/cli'
+require 'sbconstants/constant_writer'
 require 'sbconstants/objc_constant_writer'
 require 'sbconstants/swift_constant_writer'
 require 'sbconstants/location'

--- a/lib/sbconstants/cli.rb
+++ b/lib/sbconstants/cli.rb
@@ -39,7 +39,7 @@ module SBConstants
     end
     
     def sanitise_key key
-      key.gsub(" ", "").gsub("-", "").gsub("@", "").gsub(":", "").gsub("~", "_")
+      options.namespace + key.gsub(" ", "").gsub("-", "").gsub("@", "").gsub(":", "").gsub("~", "_")
     end
 
     private

--- a/lib/sbconstants/constant_writer.rb
+++ b/lib/sbconstants/constant_writer.rb
@@ -1,0 +1,10 @@
+require 'delegate'
+require 'erb'
+
+module SBConstants
+  class ConstantWriter < SimpleDelegator
+    def present_constants(section)
+      section.constants.map { |constant| [ sanitise_key(constant), constant ] }
+    end
+  end
+end

--- a/lib/sbconstants/objc_constant_writer.rb
+++ b/lib/sbconstants/objc_constant_writer.rb
@@ -1,8 +1,5 @@
-require 'delegate'
-require 'erb'
-
 module SBConstants
-  class ObjcConstantWriter < SimpleDelegator
+  class ObjcConstantWriter < ConstantWriter
     attr_reader :templates_dir
     
     def initialize data_source, int_out, imp_out, templates_dir
@@ -36,11 +33,7 @@ module SBConstants
       pre_processed_template = ERB.new(File.open(template_file_path("objc_body.erb")).read, nil, '<>').result(binding)
       ERB.new(pre_processed_template, nil, '<>').result(binding)
     end
-    
-    def present_constants(section)
-      section.constants.map { |constant| [ sanitise_key(constant), constant ] }
-    end
-    
+
     def template_file_path basename
       if templates_dir && File.exist?("#{templates_dir}/#{basename}")
         "#{templates_dir}/#{basename}"

--- a/lib/sbconstants/options.rb
+++ b/lib/sbconstants/options.rb
@@ -5,7 +5,8 @@ module SBConstants
   class Options
     attr_accessor(
       :destination,
-      :dry_run, 
+      :dry_run,
+      :namespace,
       :output_path,
       :prefix,
       :query_config,
@@ -24,7 +25,11 @@ module SBConstants
         opts.on('-d', '--dry-run', 'Output to STDOUT') do |dry_run|
           options.dry_run = dry_run
         end
-        
+
+        opts.on('-n', '--namespace=<namespace>', 'Prefix each constant with <namespace>') do |namespace|
+          options.namespace = namespace
+        end
+
         opts.on('-p', '--prefix=<prefix>', 'Only match identifiers with <prefix>') do |prefix|
           options.prefix = prefix
         end
@@ -62,6 +67,7 @@ module SBConstants
     def initialize
       self.query_file = File.expand_path('../../sbconstants/identifiers.yml', __FILE__)
       self.source_dir = Dir.pwd
+      self.namespace = ''
     end
 
     def queries

--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -6,7 +6,7 @@ module SBConstants
     attr_reader :templates_dir
 
     def initialize data_source, swift_out, templates_dir
-      super data_source
+      super(data_source)
       @swift_out = swift_out
       @templates_dir = templates_dir
     end

--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -1,8 +1,5 @@
-require 'delegate'
-require 'erb'
-
 module SBConstants
-  class SwiftConstantWriter < SimpleDelegator
+  class SwiftConstantWriter < ConstantWriter
     attr_reader :templates_dir
 
     def initialize data_source, swift_out, templates_dir
@@ -26,10 +23,6 @@ module SBConstants
       @body = body
       pre_processed_template = ERB.new(File.open(template_file_path("swift_body.erb")).read, nil, '<>').result(binding)
       ERB.new(pre_processed_template, nil, '<>').result(binding)
-    end
-
-    def present_constants(section)
-      section.constants.map { |constant| [ sanitise_key(constant), constant ] }
     end
 
     def template_file_path basename

--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -13,7 +13,7 @@ module SBConstants
 
     def write
       head = %Q{\nimport Foundation"\n}
-      body = %Q{    case <%= sanitise_key(constant) %>\n}
+      body = %Q{    case <%= sanitise_key(constant_name) %> = "<%= constant_value %>"\n}
       @swift_out.puts template_with_file head, body
     end
 
@@ -26,6 +26,10 @@ module SBConstants
       @body = body
       pre_processed_template = ERB.new(File.open(template_file_path("swift_body.erb")).read, nil, '<>').result(binding)
       ERB.new(pre_processed_template, nil, '<>').result(binding)
+    end
+
+    def present_constants(section)
+      section.constants.map { |constant| [ sanitise_key(constant), constant ] }
     end
 
     def template_file_path basename

--- a/lib/sbconstants/templates/swift_body.erb
+++ b/lib/sbconstants/templates/swift_body.erb
@@ -2,7 +2,7 @@
 <%% sections.each do |section| %>
 
 public enum <%%= section.pretty_title %> : String {
-<%% section.constants.each do |constant| %>
+<%% present_constants(section).each do |constant_name, constant_value| %>
 <%% if options.verbose %>
 //
 <%% constants[constant].each do |location| %>


### PR DESCRIPTION
I added a new option (`--namespace`) which allows to add a prefix to each constant.

This fix an issue when you have same identifier (XIB name, storyboard name...) than classname, which is typical when you work with XIB files (`whatever.xib` is the view for `whatever.h` which defines `whatever` class).
