### PR TITLE
Update README to use new GitHub markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Generate a constants file by grabbing identifiers from storyboards in a project.
 
 ## Installation
 
-    $ gem install sbconstants
+```sh
+$ gem install sbconstants
+```
 
 ## Usage
 
 For automated use:
 
 1. Add a file in Xcode to hold your constants e.g. `PASStoryboardConstants.(h|m)`
-2. Add a build script to build phases  
-        sbconstants path_to_constant_file
+2. Add a build script to build phases e.g. `sbconstants path_to_constant_file`
 3. Enjoy your identifiers being added as constants to your constants file
 
 For manual use (using swift):
@@ -37,16 +38,19 @@ Usage: DESTINATION_FILE [options]
 
 An example usage would look like:
 
-    sbconstants MyApp/Constants/PASStoryboardConstants.h
-    
+```
+sbconstants MyApp/Constants/PASStoryboardConstants.h
+```
+
 **NB** The argument is the destination file to dump the constants into - this needs to be added manually
-    
+
 Every time `sbconstants` is run it will parse the storyboard files and pull out any constants and then dump them into `PASStoryboardConstants.(h|m)`. This of course means that `PASStoryboardConstants.(h|m)` should not be edited by hand as it will just be clobbered any time we build.
 
 The output of running this tool will look something like this:
 
 `PASStoryboardConstants.h`
-```
+
+```objective-c
 // Auto generated file - any changes will be lost
 
 #import <Foundation/Foundation.h>
@@ -60,12 +64,11 @@ extern NSString * const Main;
 
 #pragma mark - tableViewCell.reuseIdentifier
 extern NSString * const PSBAwesomeCell;
-
 ```
 
 `PASStoryboardConstants.m`
-```
 
+```objective-c
 // Auto generated file - any changes will be lost
 
 #import "PASStoryboardConstants.h"
@@ -79,12 +82,11 @@ NSString * const Main = @"Main";
 
 #pragma mark - tableViewCell.reuseIdentifier
 NSString * const PSBAwesomeCell = @"PSBAwesomeCell";
-
 ```
 
 Using the `--swift` flag this would produce
 
-```
+```swift
 // Auto generated file from SBConstants - any changes may be lost
 
 public enum SegueIdentifier : String {
@@ -107,33 +109,33 @@ The constants are grouped by where they were found in the storyboard xml e.g. `s
 
 Options are fun and there are a few to play with - most of these options are really only any good for debugging.
 
-####`--prefix`
+#### `--prefix`
     -p, --prefix=<prefix>            Only match identifiers with <prefix>
-    
+
 Using the `prefix` option you can specify that you only want to grab identifiers that start with a certain prefix, which is always nice.
 
-####`--ignore=<files_to_ignore>`
+#### `--ignore=<files_to_ignore>`
     -i, --ignore=<files_to_ignore>   Comma separated list of files to ignore
 Using the `ignore` option, you can specify files which will not be added to the generated constants file. If you need to ignore several files, you need to separate it with commas (`-i MainStoryboard,HelpStoryboard,CellXIB`).
 
-####`--source-dir`
+#### `--source-dir`
     -s, --source-dir=<source>        Directory containing storyboards
-    
+
 If you don't want to run the tool from the root of your app for some reason you can specify the source directory to start searching for storyboard files. The search is recursive using a glob something like `<source-dir>/**/*.storyboard`
 
-####`--dry-run`
+#### ` --dry-run`
     -d, --dry-run                    Output to STDOUT
-    
+
 If you just want to run the tool and not write the output to a file then this option will spit the result out to `$stdout`
 
-####`--verbose`
+#### `--verbose`
     -v, --verbose                    Verbose output
-    
+
 Perhaps you want a little more context about where your identifiers are being grabbed from for debugging purposes. Never fear just use the `--verbose` switch and get output similar to:
 
 `sample output`
-```
 
+```objective-c
 #pragma mark - viewController.storyboardIdentifier
 //
 //    info: MainStoryboard[line:43](viewController.storyboardIdentifier)
@@ -143,14 +145,14 @@ NSString * const FirstViewController = @"FirstViewController";
 
 ```
 
-####`--queries`
+#### `--queries`
     -q, --queries=<queries>          YAML file containing queries
-    
+
 Chances are I've missed some identifiers to search for in the storyboard. You don't want to wait for the `gem` to be updated or have to fork it and fix it. Using this option you can provide a YAML file that contains a description of what identifers to search for. The current one looks something like this (NB this is a great starting point for creating your own yaml):
 
 `queries`
-```
 
+```
 ---
 segue: identifier
 view: restorationIdentifier
@@ -163,7 +165,6 @@ view: restorationIdentifier
   - collectionViewController
 : - storyboardIdentifier
   - restorationIdentifier
-  
 ```
 
 This looks a little funky but it's essentially groups of keys and values (both the key and the value can be an array). This actually gets expanded to the following table:
@@ -185,16 +186,16 @@ This looks a little funky but it's essentially groups of keys and values (both t
     | collectionViewController | restorationIdentifier |
     +--------------------------+-----------------------+
 
-####`--swift`
+#### `--swift`
 
     -w, --swift                      Output to a Swift File
-    
+
 Outputs Swift code rather than Objective-C
 
-####`--templates-dir`
+#### `--templates-dir`
 
     -t, --templates-dir=<templates>  Directory containing the templates to use for code formatting
-    
+
 See below
 
 ## Custom formatting
@@ -203,9 +204,8 @@ If you are running tools that verify your team is sticking to coding conventions
 
 Inside your custom templates you can interpolate the `constant_name` and `constant_value` like this
 
-```
+```objective-c
 NSString * const <%= constant_name %> = @"<%= constant_value %>";
-
 ```
 
 You can override how the Objective-C constants are formatted by creating `objc_header.erb` and `objc_implementation.erb` files and adding the `--templates-dir` flag pointing to their containing directory.


### PR DESCRIPTION
GitHub recently changed their Markdown syntax such that headings require a more specific format that in the past - this PR updates the README for the project to use this new format. 

I've also updated any relevant code blocks to use syntax highlighting for the language being used.