### PR TITLE
Scan for AppKit collectionViewItems

### DIFF
--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -16,5 +16,6 @@ tableCellView: identifier
   - collectionViewItem
   - viewControllerPlaceholder
   - tabBarController
+  - windowController
 : - storyboardIdentifier
   - restorationIdentifier

--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -3,6 +3,7 @@ segue: identifier
 view: restorationIdentifier
 controller: identifier
 tableRow: identifier
+tableCellView: identifier
 ? - tableViewCell
   - collectionViewCell
   - collectionReusableView

--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -3,6 +3,7 @@ segue: identifier
 view: restorationIdentifier
 controller: identifier
 tableRow: identifier
+tableColumn: identifier
 tableCellView: identifier
 ? - tableViewCell
   - collectionViewCell

--- a/lib/sbconstants/identifiers.yml
+++ b/lib/sbconstants/identifiers.yml
@@ -11,6 +11,7 @@ tableRow: identifier
   - viewController
   - tableViewController
   - collectionViewController
+  - collectionViewItem
   - viewControllerPlaceholder
   - tabBarController
 : - storyboardIdentifier


### PR DESCRIPTION
I'm not sure if the existing `collectionViewController` in `identifiers.yml` is the version for iOS, but in macOS projects, collection views are stored in `collectionViewItem` XML nodes in the Storyboard.

I've added support for both `collectionViewItems`, `tableColumn` and `tableCellView`.

This PR adds these items to the identifiers list.