### PR TITLE
When a constant doesn’t match it’s sanitised form, output the quoted constant

### DIFF
--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -13,7 +13,7 @@ module SBConstants
 
     def write
       head = %Q{\nimport Foundation"\n}
-      body = %Q{    case <%= sanitise_key(constant) %>\n}
+      body = %Q{    <%= sanitised_case_writer(constant) %>\n}
       @swift_out.puts template_with_file head, body
     end
 
@@ -33,6 +33,16 @@ module SBConstants
         "#{templates_dir}/#{basename}"
       else
         "#{default_templates_dir}/#{basename}"
+      end
+    end
+
+    def sanitised_case_writer constant
+      sanitised_key = sanitise_key(constant)
+
+      if constant.eql? sanitised_key
+        "case #{sanitised_key}"
+      else
+        "case #{sanitised_key} = \"#{constant}\""
       end
     end
 

--- a/lib/sbconstants/swift_constant_writer.rb
+++ b/lib/sbconstants/swift_constant_writer.rb
@@ -12,20 +12,20 @@ module SBConstants
     end
 
     def write
-      head = %Q{\nimport Foundation"\n}
-      body = %Q{    <%= sanitised_case_writer(constant) %>\n}
-      @swift_out.puts template_with_file head, body
+      @swift_out.puts template_with_file
     end
 
     def default_templates_dir
       @default_templates_dir ||= File.dirname(__FILE__) + '/templates'
     end
 
-    def template_with_file head, body
-      @head = head
-      @body = body
-      pre_processed_template = ERB.new(File.open(template_file_path("swift_body.erb")).read, nil, '<>').result(binding)
-      ERB.new(pre_processed_template, nil, '<>').result(binding)
+    def template_with_file
+      pre_processed_template = ERB.new(File.open(template_file_path("swift_body.erb")).read, nil, '-').result(binding)
+      ERB.new(pre_processed_template, nil, '-').result(binding)
+    end
+
+    def present_constants(section)
+      section.constants.map { |constant| [ sanitise_key(constant), constant ] }
     end
 
     def template_file_path basename
@@ -33,16 +33,6 @@ module SBConstants
         "#{templates_dir}/#{basename}"
       else
         "#{default_templates_dir}/#{basename}"
-      end
-    end
-
-    def sanitised_case_writer constant
-      sanitised_key = sanitise_key(constant)
-
-      if constant.eql? sanitised_key
-        "case #{sanitised_key}"
-      else
-        "case #{sanitised_key} = \"#{constant}\""
       end
     end
 

--- a/lib/sbconstants/templates/swift_body.erb
+++ b/lib/sbconstants/templates/swift_body.erb
@@ -1,17 +1,22 @@
 // Auto generated file from SBConstants - any changes may be lost
-<%% sections.each do |section| %>
 
-public enum <%%= section.pretty_title %> : String {
-<%% section.constants.each do |constant| %>
-<%% if options.verbose %>
-//
-<%% constants[constant].each do |location| %>
-//    info: <%%= location.debug %>
-// context: <%%= location.context %>
-//
-<%% end %>
-<%% end %>
-<%= @body %>
-<%% end %>
-}
-<%% end %>
+<%- sections.each do |section| -%>
+
+  public enum <%= section.pretty_title %>: String {
+  <%- present_constants(section).each do |constant_name, constant_value| -%>
+  <%- if options.verbose -%>
+      //
+    <%- constants[constant_name].each do |location| -%>
+      //    info: <%= location.debug %>
+      // context: <%= location.context %>
+      //
+    <%- end -%>
+  <%- end -%>
+  <%- if constant_name.eql? constant_value -%>
+      case <%= constant_name %>
+  <%- else -%>
+      case <%= constant_name %> = "<%= constant_value %>"
+  <%- end -%>
+  <%- end -%>
+  }
+  <%- end -%>

--- a/lib/sbconstants/templates/swift_body.erb
+++ b/lib/sbconstants/templates/swift_body.erb
@@ -2,21 +2,21 @@
 
 <%- sections.each do |section| -%>
 
-  public enum <%= section.pretty_title %>: String {
-  <%- present_constants(section).each do |constant_name, constant_value| -%>
-  <%- if options.verbose -%>
-      //
-    <%- constants[constant_name].each do |location| -%>
-      //    info: <%= location.debug %>
-      // context: <%= location.context %>
-      //
-    <%- end -%>
+public enum <%= section.pretty_title %>: String {
+<%- present_constants(section).each do |constant_name, constant_value| -%>
+<%- if options.verbose -%>
+    //
+  <%- constants[constant_name].each do |location| -%>
+    //    info: <%= location.debug %>
+    // context: <%= location.context %>
+    //
   <%- end -%>
-  <%- if constant_name.eql? constant_value -%>
-      case <%= constant_name %>
-  <%- else -%>
-      case <%= constant_name %> = "<%= constant_value %>"
-  <%- end -%>
-  <%- end -%>
-  }
-  <%- end -%>
+<%- end -%>
+<%- if constant_name.eql? constant_value -%>
+    case <%= constant_name %>
+<%- else -%>
+    case <%= constant_name %> = "<%= constant_value %>"
+<%- end -%>
+<%- end -%>
+}
+<%- end -%>


### PR DESCRIPTION
This PR fixes the issue raised in #52.

This is useful when the storyboard file name on disk has spaces or other characters that are stripped by the string sanitiser.

Before the changes introduced in this PR:

```swift
public enum StoryboardNames: String {
    case ConstantsProperties
    case DebugLog // filename is actually "Debug Log.storyboard"
    case DocumentProperties   
}
```

After the changes introduced in this PR:

```swift
public enum StoryboardNames: String {
    case ConstantsProperties
    case DebugLog = "Debug Log"
    case DocumentProperties
}
```
